### PR TITLE
Implement in-toto attestation format for release identity

### DIFF
--- a/.github/workflows/slsa-trusted-release.yml
+++ b/.github/workflows/slsa-trusted-release.yml
@@ -114,34 +114,43 @@ jobs:
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "Using commit: $COMMIT_SHA with tag: $TAG_NAME for provenance"
 
-      # Generate release-identity.json file for SLSA verification
+      # Generate release-identity.intoto.jsonl file for SLSA verification
       # Note: We intentionally do not include source code archives (zip/tar.gz) in the SLSA provenance
       # because GitHub does not guarantee their stability over time:
       # - https://docs.github.com/en/repositories/working-with-files/using-files/downloading-source-code-archives#stability-of-source-code-archives
       # - https://github.blog/open-source/git/update-on-the-future-stability-of-source-code-archives-and-hashes/
-      # Instead, we include the commit SHA in release-identity.json and verify that it matches the SHA that the tag points to.
+      # Instead, we include the commit SHA in release-identity.intoto.jsonl and verify that it matches the SHA that the tag points to.
       - name: Generate release identity file
         id: generate-metadata
         run: |
           REPO_NAME="${GITHUB_REPOSITORY#*/}"
-          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          CREATED_AT=$(date +%s)  # Unix timestamp (seconds since epoch)
 
-          # Create release-identity.json file
-          cat > release-identity.json << EOF
+          # Create release-identity.intoto.jsonl file using in-toto Statement format
+          cat > release-identity.intoto.jsonl << EOF
           {
-            "name": "$REPO_NAME",
-            "version": "${{ needs.version.outputs.tag_name }}",
-            "timestamp": "$TIMESTAMP",
-            "description": "This file contains identity information about this GitHub release. It can be verified with the release-identity.intoto.jsonl file to confirm the authenticity and build source of this release.",
-            "git": {
-              "commit": "${{ github.sha }}",
-              "tag": "${{ needs.version.outputs.tag_name }}",
-              "repository": "https://github.com/$GITHUB_REPOSITORY"
+            "_type": "https://in-toto.io/Statement/v0.1",
+            "predicateType": "https://github.com/actionutils/trusted-tag-releaser/in-toto/release-identity/v1",
+            "subject": [
+              {
+                "name": "$REPO_NAME",
+                "digest": {
+                  "git": "${{ github.sha }}"
+                }
+              }
+            ],
+            "predicate": {
+              "version": "${{ needs.version.outputs.tag_name }}",
+              "created_at": $CREATED_AT,
+              "git": {
+                "tag": "${{ needs.version.outputs.tag_name }}",
+                "repository": "https://github.com/$GITHUB_REPOSITORY"
+              }
             }
           }
           EOF
 
-          echo "Generated release-identity.json"
+          echo "Generated release-identity.intoto.jsonl"
 
       # Generate base64-subjects directly
       - name: Generate subjects
@@ -149,21 +158,21 @@ jobs:
         run: |
           # sha256sum generates output in format "<hash> <filename>" which is exactly what we need
           # base64 -w0 encodes to base64 and outputs on a single line
-          echo "base64-subjects=$(sha256sum release-identity.json | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "base64-subjects=$(sha256sum release-identity.intoto.jsonl | base64 -w0)" >> $GITHUB_OUTPUT
 
 
-      # Upload release-identity.json as an artifact to share between jobs
+      # Upload release-identity.intoto.jsonl as an artifact to share between jobs
       - name: Upload release identity artifact
         id: upload-identity
         uses: actions/upload-artifact@v4
         with:
-          name: release-identity-json
-          path: release-identity.json
+          name: release-identity-intoto
+          path: release-identity.intoto.jsonl
           retention-days: 1
 
       - uses: actions/attest-build-provenance@v2
         with:
-          subject-path: release-identity.json
+          subject-path: release-identity.intoto.jsonl
 
   # Generate SLSA provenance using reusable workflow
   generate-provenance:
@@ -179,6 +188,7 @@ jobs:
       upload-assets: true
       upload-tag-name: ${{ needs.version.outputs.tag_name }}
       draft-release: true
+      provenance-name: provenance.intoto.jsonl
 
   # Create GitHub Release job
   release:
@@ -197,10 +207,10 @@ jobs:
 
       # Download the artifacts from previous jobs
 
-      - name: Download release-identity.json
+      - name: Download release-identity.intoto.jsonl
         uses: actions/download-artifact@v4
         with:
-          name: release-identity-json
+          name: release-identity-intoto
 
       # Update existing draft release
       - name: Update GitHub Release
@@ -211,7 +221,7 @@ jobs:
           TAG_NAME="${{ needs.prepare-slsa.outputs.tag_name }}"
 
           # Upload artifacts to the release
-          gh release upload "$TAG_NAME" release-identity.json --clobber
+          gh release upload "$TAG_NAME" release-identity.intoto.jsonl --clobber
 
           # Update the existing draft release
           RELEASE_URL=$(gh release edit "$TAG_NAME" \
@@ -248,16 +258,16 @@ jobs:
           TAG_NAME="${{ needs.prepare-slsa.outputs.tag_name }}"
           TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
 
-          # Download the specific attestation file and release-identity.json
-          gh release download "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --pattern "release-identity.json.intoto.jsonl" --dir "$TEMP_DIR"
-          gh release download "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --pattern "release-identity.json" --dir "$TEMP_DIR"
+          # Download the specific attestation file and release-identity.intoto.jsonl
+          gh release download "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --pattern "provenance.intoto.jsonl" --dir "$TEMP_DIR"
+          gh release download "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --pattern "release-identity.intoto.jsonl" --dir "$TEMP_DIR"
 
           echo "Downloaded files to: $TEMP_DIR"
           ls -la "$TEMP_DIR"
 
       # Verify provenance and commit SHA
       # Since we don't include source code archives in the SLSA provenance due to their instability,
-      # we instead verify that the commit SHA in release-identity.json matches the SHA that the tag points to.
+      # we instead verify that the commit SHA in release-identity.intoto.jsonl matches the SHA that the tag points to.
       # This provides a more reliable verification mechanism that isn't affected by GitHub's archive generation process.
       - name: Verify SLSA provenance and commit SHA
         env:
@@ -268,8 +278,8 @@ jobs:
           TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
 
           # Use the specific attestation file and identity file
-          ATTESTATION_FILE="$TEMP_DIR/release-identity.json.intoto.jsonl"
-          IDENTITY_FILE="$TEMP_DIR/release-identity.json"
+          ATTESTATION_FILE="$TEMP_DIR/provenance.intoto.jsonl"
+          IDENTITY_FILE="$TEMP_DIR/release-identity.intoto.jsonl"
 
           if [ -z "$ATTESTATION_FILE" ]; then
             echo "Error: No attestation file found"
@@ -277,7 +287,7 @@ jobs:
           fi
 
           if [ -z "$IDENTITY_FILE" ]; then
-            echo "Error: No release-identity.json file found"
+            echo "Error: No release-identity.intoto.jsonl file found"
             exit 1
           fi
 
@@ -292,11 +302,11 @@ jobs:
 
           echo "✅ Provenance verification successful!"
 
-          # Verify that the commit SHA in release-identity.json matches the SHA that the tag points to
-          echo "Verifying commit SHA in release-identity.json..."
+          # Verify that the commit SHA in release-identity.intoto.jsonl matches the SHA that the tag points to
+          echo "Verifying commit SHA in release-identity.intoto.jsonl..."
 
-          # Get the commit SHA from release-identity.json
-          IDENTITY_COMMIT_SHA=$(jq -r '.git.commit' "$IDENTITY_FILE")
+          # Get the commit SHA from release-identity.intoto.jsonl
+          IDENTITY_COMMIT_SHA=$(jq -r '.subject[0].digest.git' "$IDENTITY_FILE")
 
           # Get the commit SHA that the tag points to using GitHub API
           # First, get the tag SHA
@@ -306,12 +316,12 @@ jobs:
           # Then, get the commit SHA that the tag points to
           TAG_COMMIT_SHA=$(gh api repos/$REPO_NAME/git/tags/$TAG_SHA --jq '.object.sha')
 
-          echo "Commit SHA in release-identity.json: $IDENTITY_COMMIT_SHA"
+          echo "Commit SHA in release-identity.intoto.jsonl: $IDENTITY_COMMIT_SHA"
           echo "Commit SHA that tag $TAG_NAME points to: $TAG_COMMIT_SHA"
 
           # Verify that the commit SHAs match
           if [ "$IDENTITY_COMMIT_SHA" != "$TAG_COMMIT_SHA" ]; then
-            echo "❌ Commit SHA verification failed! The commit SHA in release-identity.json does not match the SHA that the tag points to."
+            echo "❌ Commit SHA verification failed! The commit SHA in release-identity.intoto.jsonl does not match the SHA that the tag points to."
             exit 1
           fi
 
@@ -320,8 +330,8 @@ jobs:
       - name: Print provenance
         run: |
           TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
-          ATTESTATION_FILE="$TEMP_DIR/release-identity.json.intoto.jsonl"
-          IDENTITY_FILE="$TEMP_DIR/release-identity.json"
+          ATTESTATION_FILE="$TEMP_DIR/provenance.intoto.jsonl"
+          IDENTITY_FILE="$TEMP_DIR/release-identity.intoto.jsonl"
           REPO_NAME="${GITHUB_REPOSITORY}"
 
           echo "Printing provenance information:"
@@ -338,8 +348,8 @@ jobs:
           GH_FORCE_TTY: 1
         run: |
           TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
-          IDENTITY_FILE="$TEMP_DIR/release-identity.json"
-          echo "Verifying build provenance attestation for release-identity.json"
+          IDENTITY_FILE="$TEMP_DIR/release-identity.intoto.jsonl"
+          echo "Verifying build provenance attestation for release-identity.intoto.jsonl"
 
           gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY
 

--- a/in-toto/release-identity/v1/README.md
+++ b/in-toto/release-identity/v1/README.md
@@ -1,0 +1,132 @@
+# Predicate type: Release Identity
+
+Type URI: `https://github.com/actionutils/trusted-tag-releaser/in-toto/release-identity/v1`
+
+Version: 1
+
+Predicate Name: Release Identity
+
+## Purpose
+
+The Release Identity predicate provides a standardized way to attest to the identity and origin of a release. It captures essential metadata about a release, including version information, creation timestamp, and Git repository details. This predicate enables verification of release authenticity by establishing a clear link between a release artifact and its source repository.
+
+This predicate is particularly useful for products where the tag itself is considered a release (GitHub Actions, reusable workflows, Go/Deno modules, Vim plugins, etc.). For these types of products, there might not be concrete artifacts, but the tag and the commit SHA it points to are critical pieces of information for verification. That's why this predicate includes both the tag and the SHA it references.
+
+The Release Identity predicate is primarily designed to be used with the trusted-tag-releaser tool, which creates releases through labeled Pull Requests. In the future, this predicate could be extended to include information about whether the release PR was properly reviewed, providing additional verification capabilities for the release process.
+
+## Use Cases
+
+### Release Verification
+
+When a release is created, it's important to be able to verify its authenticity and origin. The Release Identity predicate addresses this by providing:
+
+1. A link to the specific Git commit that the release was built from
+2. The tag associated with the release
+3. The timestamp when the release was created
+4. The repository where the release originated
+
+Current predicate types like SLSA Provenance focus on how an artifact was built, but don't specifically address the release identity information. This predicate fills that gap by providing a standardized way to attest to release identity.
+
+### Tag-Based Releases
+
+Many GitHub-hosted projects use Git tags as the primary mechanism for releases. This is especially common for:
+
+- GitHub Actions and reusable workflows
+- Go and Deno modules
+- Vim/Emacs plugins
+- Other libraries and tools where the tag itself signifies a release
+
+For these projects, the tag and the commit it points to are the most important pieces of information for verification. The Release Identity predicate provides a standardized way to capture and verify this information, ensuring that consumers can verify they're using a legitimate release from the expected source.
+
+### Supply Chain Security
+
+In the context of supply chain security, it's crucial to be able to verify that a release came from the expected source. The Release Identity predicate enables:
+
+- Verification that a release artifact corresponds to a specific Git commit
+- Confirmation that the release was created at the expected time
+- Validation that the release came from the authorized repository
+
+## Prerequisites
+
+- The [in-toto Attestation Framework](https://github.com/in-toto/attestation) is required for understanding and using this predicate type.
+- Git version control system concepts (commits, tags, repositories)
+- Basic understanding of software release processes
+
+## Model
+
+The Release Identity predicate is relevant to the following supply chain phases:
+
+- **Release**: The phase where software is packaged and published for distribution
+- **Verification**: The phase where consumers verify the authenticity of the release
+
+The predicate is created by the release functionary (typically a CI/CD system) and consumed by verifiers who want to confirm the authenticity of a release.
+
+## Schema
+
+### Parsing Rules
+
+The Release Identity predicate follows the [standard parsing rules](https://github.com/in-toto/attestation/blob/main/spec/v0.1.0/README.md#parsing-rules) defined in the in-toto Attestation Framework. Additionally:
+
+- Unknown fields in the predicate MUST be ignored by parsers
+- The `created_at` field MUST be interpreted as seconds since the Unix epoch (January 1, 1970, 00:00:00 UTC)
+- The `version` field SHOULD follow semantic versioning format, but this is not strictly required
+
+### Fields
+
+#### Statement Fields
+
+The standard in-toto Statement fields apply:
+
+- `_type`: MUST be `https://in-toto.io/Statement/v0.1`
+- `subject`: MUST contain at least one entry with:
+  - `name`: The name of the repository
+  - `digest`: MUST contain a `git` key with the commit SHA as its value
+
+#### Predicate Fields
+
+- `predicateType`: MUST be `https://github.com/actionutils/trusted-tag-releaser/in-toto/release-identity/v1`
+- `predicate`: An object with the following fields:
+  - `version` (required, string): The semantic version tag of the release
+  - `created_at` (required, integer): Unix timestamp (seconds since epoch) when the attestation was generated during release
+  - `git` (required, object): Git-specific information with the following fields:
+    - `tag` (required, string): The Git tag name for the release
+    - `repository` (required, string): The GitHub repository URL
+
+## Example
+
+```json
+{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "predicateType": "https://github.com/actionutils/trusted-tag-releaser/in-toto/release-identity/v1",
+  "subject": [
+    {
+      "name": "trusted-tag-releaser",
+      "digest": {
+        "git": "abcdef1234567890abcdef1234567890abcdef12"
+      }
+    }
+  ],
+  "predicate": {
+    "version": "v1.2.3",
+    "created_at": 1712851200,
+    "git": {
+      "tag": "v1.2.3",
+      "repository": "https://github.com/actionutils/trusted-tag-releaser"
+    }
+  }
+}
+```
+
+## Verification
+
+Verification of a Release Identity attestation should include:
+
+1. Validating that the attestation follows the in-toto Statement format
+2. Validating that the predicate follows the schema defined above
+3. Verifying that the commit SHA in the subject's digest matches the SHA that the tag points to
+4. Verifying that the tag in the predicate matches the tag in the repository
+
+
+## Changelog and Migrations
+
+This is the initial version (v1) of the Release Identity predicate type, so no migrations are necessary.

--- a/in-toto/release-identity/v1/schema.json
+++ b/in-toto/release-identity/v1/schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ReleaseIdentityPredicate",
+  "description": "Predicate for release identity information",
+  "type": "object",
+  "required": ["version", "created_at", "git"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "The semantic version tag of the release"
+    },
+    "created_at": {
+      "type": "integer",
+      "description": "Unix timestamp (seconds since epoch) when the attestation was generated during release"
+    },
+    "git": {
+      "type": "object",
+      "required": ["tag", "repository"],
+      "properties": {
+        "tag": {
+          "type": "string",
+          "description": "The Git tag name for the release"
+        },
+        "repository": {
+          "type": "string",
+          "description": "The GitHub repository URL",
+          "format": "uri"
+        }
+      }
+    }
+  }
+}

--- a/in-toto/release-identity/v1/schema.proto
+++ b/in-toto/release-identity/v1/schema.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package actionutils.trusted_tag_releaser.in_toto.release_identity.v1;
+
+// ReleaseIdentityPredicate defines the structure for release identity information
+// in the in-toto attestation framework.
+message ReleaseIdentityPredicate {
+  // The semantic version tag of the release
+  string version = 1;
+  
+  // Unix timestamp (seconds since epoch) when the attestation was generated during release
+  int64 created_at = 2;
+  
+  // Git-specific information about the release
+  GitInfo git = 3;
+  
+  // GitInfo contains Git repository and tag information
+  message GitInfo {
+    // The Git tag name for the release
+    string tag = 1;
+    
+    // The GitHub repository URL
+    string repository = 2;
+  }
+}


### PR DESCRIPTION
This PR implements the in-toto attestation format for the release identity file as described in the design document.

## Key changes:

1. Restructuring the data into the in-toto Statement format
2. Renaming the file from release-identity.json to release-identity.intoto.jsonl
3. Using Unix timestamp (created_at) instead of string timestamp
4. Specifying provenance.intoto.jsonl as the name for the provenance file
5. Updating all references and verification logic to work with the new format
6. Adding in-toto specification files for the release identity predicate:
   - README.md following the in-toto predicate template format
   - Protocol Buffers schema definition
   - JSON Schema definition

This implementation follows the design document at docs/design_docs/20250411_in_toto_attestation_format_for_release_identity.md and improves interoperability with other supply chain security tools and standards.