### PR TITLE
Update in-toto predicate type URLs to include tree/main

### DIFF
--- a/.github/workflows/slsa-trusted-release.yml
+++ b/.github/workflows/slsa-trusted-release.yml
@@ -130,7 +130,7 @@ jobs:
           cat > release-identity.intoto.jsonl << EOF
           {
             "_type": "https://in-toto.io/Statement/v0.1",
-            "predicateType": "https://github.com/actionutils/trusted-tag-releaser/in-toto/release-identity/v1",
+            "predicateType": "https://github.com/actionutils/trusted-tag-releaser/tree/main/in-toto/release-identity/v1",
             "subject": [
               {
                 "name": "$REPO_NAME",

--- a/in-toto/release-identity/v1/README.md
+++ b/in-toto/release-identity/v1/README.md
@@ -1,6 +1,6 @@
 # Predicate type: Release Identity
 
-Type URI: `https://github.com/actionutils/trusted-tag-releaser/in-toto/release-identity/v1`
+Type URI: `https://github.com/actionutils/trusted-tag-releaser/tree/main/in-toto/release-identity/v1`
 
 Version: 1
 
@@ -84,7 +84,7 @@ The standard in-toto Statement fields apply:
 
 #### Predicate Fields
 
-- `predicateType`: MUST be `https://github.com/actionutils/trusted-tag-releaser/in-toto/release-identity/v1`
+- `predicateType`: MUST be `https://github.com/actionutils/trusted-tag-releaser/tree/main/in-toto/release-identity/v1`
 - `predicate`: An object with the following fields:
   - `version` (required, string): The semantic version tag of the release
   - `created_at` (required, integer): Unix timestamp (seconds since epoch) when the attestation was generated during release
@@ -97,7 +97,7 @@ The standard in-toto Statement fields apply:
 ```json
 {
   "_type": "https://in-toto.io/Statement/v0.1",
-  "predicateType": "https://github.com/actionutils/trusted-tag-releaser/in-toto/release-identity/v1",
+  "predicateType": "https://github.com/actionutils/trusted-tag-releaser/tree/main/in-toto/release-identity/v1",
   "subject": [
     {
       "name": "trusted-tag-releaser",


### PR DESCRIPTION
This PR updates all URLs in the in-toto specification and workflow file to include 'tree/main' in the path:

1. Updated Type URI in README.md
2. Updated predicateType in README.md and example JSON
3. Updated predicateType in the workflow file

This ensures the URLs correctly point to the specification files in the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised release metadata in user-facing documentation to display updated URL references.
- **Chores**
  - Modified internal release configuration to adopt a new repository path structure for metadata consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->