### PR TITLE
Add GitHub release notes generation API to workflows

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -46,6 +46,8 @@ jobs:
 
       # Add release information to job summary
       - name: Add release information to job summary
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           echo "# Release Check Summary" >> $GITHUB_STEP_SUMMARY
 
@@ -80,6 +82,24 @@ jobs:
 
               # Add GitHub compare link
               echo "📊 **Changes:** [View changes since $CURRENT_VERSION]($COMPARE_URL)" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+
+              # Generate and add release notes using GitHub API
+              echo "### 📝 Release Notes Preview" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+
+              # Call GitHub API to generate release notes
+              REPO="${{ github.repository }}"
+              RELEASE_NOTES=$(gh api \
+                --method POST \
+                -H "Accept: application/vnd.github+json" \
+                "/repos/${REPO}/releases/generate-notes" \
+                -f target_commitish="${{ github.sha }}" \
+                -f tag_name="$NEXT_VERSION" \
+                --jq '.body')
+
+              # Add the generated release notes to the summary
+              echo "$RELEASE_NOTES" >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
             fi
           fi

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -237,8 +237,7 @@ jobs:
           RELEASE_URL=$(gh release edit "$TAG_NAME" \
             --title "Release $TAG_NAME" \
             --draft=${{ inputs.draft }} \
-            --notes "$RELEASE_NOTES" \
-            release-identity.intoto.jsonl)
+            --notes "$RELEASE_NOTES")
 
           echo "release_url=$RELEASE_URL" >> $GITHUB_OUTPUT
           echo "Release URL: $RELEASE_URL"

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -198,7 +198,7 @@ jobs:
     permissions:
       contents: write # Required for release creation
     outputs:
-      release_url: ${{ steps.create_release.outputs.release_url }}
+      release_url: ${{ steps.update_release.outputs.release_url }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -212,18 +212,32 @@ jobs:
         with:
           name: release-identity-intoto
 
-      # Create release
-      - name: Create GitHub Release
-        id: create_release
+      # Update release
+      - name: Update GitHub Release
+        id: update_release
         env:
           GITHUB_TOKEN: ${{ secrets.github-token }}
         run: |
           TAG_NAME="${{ needs.prepare-slsa.outputs.tag_name }}"
+          REPO="${GITHUB_REPOSITORY}"
 
-          RELEASE_URL=$(gh release create "$TAG_NAME" \
+          # Upload artifacts to the release
+          gh release upload "$TAG_NAME" release-identity.intoto.jsonl --clobber
+
+          # Generate release notes using GitHub API
+          echo "Generating release notes using GitHub API..."
+          RELEASE_NOTES=$(gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${REPO}/releases/generate-notes" \
+            -f tag_name="$TAG_NAME" \
+            --jq '.body')
+
+          # Update release with generated notes
+          RELEASE_URL=$(gh release edit "$TAG_NAME" \
             --title "Release $TAG_NAME" \
-            --generate-notes \
             --draft=${{ inputs.draft }} \
+            --notes "$RELEASE_NOTES" \
             release-identity.intoto.jsonl)
 
           echo "release_url=$RELEASE_URL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR adds GitHub's generate-release-note API to both workflow files:

1. In :
   - Added code to call the GitHub API to generate release notes
   - Used those notes when updating the release

2. In :
   - Added code to call the GitHub API to generate release notes with the target_commitish parameter
   - Added the generated notes to the GitHub job summary

This provides automatic, comprehensive release notes for both the release preview and the actual GitHub release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically generated release notes are now displayed as a dedicated summary section.
  - The release process now updates existing release details seamlessly while incorporating artifact uploads.
  - Enhanced authentication enables accurate generation of notes based on recent commits and version data.
  - These updates simplify release management and provide detailed, up-to-date insights for improved user visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->