### PR TITLE
Simplify handling of previous_tag_name parameter by using empty string

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -93,13 +93,12 @@ jobs:
               # Call GitHub API to generate release notes
               REPO="${{ github.repository }}"
               
-              # Set previous_tag_name parameter if current version exists
-              PREV_TAG_PARAM=""
+              # Set previous_tag_name parameter (empty string if no current version)
               if [[ -n "$CURRENT_VERSION" ]]; then
                 echo "Using previous tag: $CURRENT_VERSION for release notes"
-                PREV_TAG_PARAM="-f previous_tag_name=\"$CURRENT_VERSION\""
               else
-                echo "No previous version found, generating release notes without previous_tag_name"
+                echo "No previous version found, using empty string for previous_tag_name"
+                CURRENT_VERSION=""
               fi
               
               # Call the API with the parameters
@@ -109,7 +108,7 @@ jobs:
                 "/repos/${REPO}/releases/generate-notes" \
                 -f target_commitish="${{ github.sha }}" \
                 -f tag_name="$NEXT_VERSION" \
-                $PREV_TAG_PARAM \
+                -f previous_tag_name="$CURRENT_VERSION" \
                 --jq '.body')
 
               # Add the generated release notes to the summary

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -93,15 +93,7 @@ jobs:
               # Call GitHub API to generate release notes
               REPO="${{ github.repository }}"
               
-              # Set previous_tag_name parameter (empty string if no current version)
-              if [[ -n "$CURRENT_VERSION" ]]; then
-                echo "Using previous tag: $CURRENT_VERSION for release notes"
-              else
-                echo "No previous version found, using empty string for previous_tag_name"
-                CURRENT_VERSION=""
-              fi
-              
-              # Call the API with the parameters
+              # Call the API with the parameters (CURRENT_VERSION will be empty string if not set)
               RELEASE_NOTES=$(gh api \
                 --method POST \
                 -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -229,13 +229,12 @@ jobs:
           # Get the current version from bumpr output
           CURRENT_VERSION="${{ needs.version.outputs.current_version }}"
           
-          # Set previous_tag_name parameter if current version exists
-          PREV_TAG_PARAM=""
+          # Set previous_tag_name parameter (empty string if no current version)
           if [[ -n "$CURRENT_VERSION" ]]; then
             echo "Using previous tag: $CURRENT_VERSION for release notes"
-            PREV_TAG_PARAM="-f previous_tag_name=\"$CURRENT_VERSION\""
           else
-            echo "No previous version found, generating release notes without previous_tag_name"
+            echo "No previous version found, using empty string for previous_tag_name"
+            CURRENT_VERSION=""
           fi
           
           # Call the API with the parameters
@@ -244,7 +243,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "/repos/${REPO}/releases/generate-notes" \
             -f tag_name="$TAG_NAME" \
-            $PREV_TAG_PARAM \
+            -f previous_tag_name="$CURRENT_VERSION" \
             --jq '.body')
 
           # Update release with generated notes

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -226,16 +226,8 @@ jobs:
 
           # Generate release notes using GitHub API
           echo "Generating release notes using GitHub API..."
-          # Get the current version from bumpr output
+          # Get the current version from bumpr output (will be empty string if not set)
           CURRENT_VERSION="${{ needs.version.outputs.current_version }}"
-          
-          # Set previous_tag_name parameter (empty string if no current version)
-          if [[ -n "$CURRENT_VERSION" ]]; then
-            echo "Using previous tag: $CURRENT_VERSION for release notes"
-          else
-            echo "No previous version found, using empty string for previous_tag_name"
-            CURRENT_VERSION=""
-          fi
           
           # Call the API with the parameters
           RELEASE_NOTES=$(gh api \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the release note generation process by simplifying how version information is passed. Now, the current version is used directly—falling back to an empty value when absent—to ensure consistent, clear release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->