### PR TITLE
refactor: switch to SLSA generator v2.1.0 for tag SHA provenance (minor)

### DIFF
--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -281,13 +281,14 @@ jobs:
 
           # Create a deterministic virtual artifact content directly from GitHub API (includes trailing newline)
           # Equivalent to: git rev-parse <tag>
-          gh api "repos/$GITHUB_REPOSITORY/git/refs/tags/$TAG_NAME" --jq '.object.sha' > release-tag.sha
+          FILENAME="${TAG_NAME}.sha"
+          gh api "repos/$GITHUB_REPOSITORY/git/refs/tags/$TAG_NAME" --jq '.object.sha' > "$FILENAME"
 
           # Encode the exact sha256sum output ("<sha256>  <name>") as base64 for the SLSA generator
-          BASE64_SUBJECTS=$(sha256sum release-tag.sha | base64 -w0)
+          BASE64_SUBJECTS=$(sha256sum "$FILENAME" | base64 -w0)
 
           echo "base64_subjects=$BASE64_SUBJECTS" >> "$GITHUB_OUTPUT"
-          echo "Computed tag SHA (rev-parse): $(cat release-tag.sha)"
+          echo "Computed tag SHA (rev-parse): $(cat "$FILENAME")"
 
 
   # Generate and upload SLSA provenance for the tag SHA artifact BEFORE creating the release content
@@ -396,7 +397,8 @@ jobs:
           TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
 
           # Get git rev-parse <tag> equivalent via GitHub API and write to file for verification
-          gh api "repos/$REPO_NAME/git/refs/tags/$TAG_NAME" --jq '.object.sha' > "$TEMP_DIR/release-tag.sha"
+          TAG_SHA_FILE="$TEMP_DIR/${TAG_NAME}.sha"
+          gh api "repos/$REPO_NAME/git/refs/tags/$TAG_NAME" --jq '.object.sha' > "$TAG_SHA_FILE"
 
           # Download provenance uploaded by SLSA generator
           PROV_NAME='${{ needs.slsa-provenance.outputs.provenance-name }}'
@@ -407,7 +409,7 @@ jobs:
             --source-uri "github.com/$REPO_NAME" \
             --source-tag "$TAG_NAME" \
             --provenance-path "$TEMP_DIR/$PROV_NAME" \
-            "$TEMP_DIR/release-tag.sha"
+            "$TAG_SHA_FILE"
 
           echo "✅ SLSA provenance verification successful"
 

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -331,10 +331,67 @@ jobs:
             -f previous_tag_name="$CURRENT_VERSION" \
             --jq '.body')
 
-          # Edit existing draft release (created by SLSA generator) with generated notes
+          # Append verification instructions to the generated release notes
+          NOTES_FILE="$(mktemp)"
+          {
+            echo "$RELEASE_NOTES"
+            echo
+            cat <<EOF
+<details>
+<summary>📋 Release Verification Instructions</summary>
+
+Verify this release and its tag provenance using the following examples.
+
+---
+
+1) Using slsa-verifier (same approach as our verify-release job)
+
+```
+# Set variables
+REPO="${REPO}"
+TAG="${TAG_NAME}"
+
+# Verify SLSA provenance for the tag SHA virtual artifact
+slsa-verifier verify-artifact \
+  --source-uri "github.com/${REPO}" \
+  --provenance-path <(curl -fsSL "https://github.com/${REPO}/releases/download/${TAG}/release-provenance.intoto.jsonl") \
+  <(gh api "repos/${REPO}/git/refs/tags/${TAG}" --jq '.object.sha')
+```
+
+Expected output includes a success message indicating the provenance matches the source and subject.
+
+---
+
+2) Using actionutils/trusted-tag-verifier (GitHub Actions example)
+
+Add a lightweight workflow step to verify the signed tag for this release:
+
+```
+name: Verify Release Tag
+on: [workflow_dispatch]
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify tag signature and identity
+        uses: actionutils/trusted-tag-verifier@v0
+        with:
+          verify: '${REPO}@${TAG_NAME}'
+          fail-on-verification-error: 'true'
+          certificate-oidc-issuer: 'https://token.actions.githubusercontent.com'
+          certificate-identity-regexp: '^https://github.com/actionutils/trusted-tag-releaser'
+```
+
+Adjust the identity regexp to your policy if you fork this workflow.
+
+</details>
+EOF
+          } > "$NOTES_FILE"
+
+          # Edit existing draft release (created by SLSA generator) with generated notes + verification section
           RELEASE_URL=$(gh release edit "$TAG_NAME" \
             --title "Release $TAG_NAME" \
-            --notes "$RELEASE_NOTES" \
+            --notes-file "$NOTES_FILE" \
             --draft=${{ inputs.draft }})
 
           echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
@@ -367,7 +424,7 @@ jobs:
           TAG="${{ needs.version.outputs.tag_name }}"
           slsa-verifier verify-artifact \
             --source-uri "github.com/$REPO_NAME" \
-            --provenance-path <(curl -sfSL "https://github.com/$REPO_NAME/releases/download/release-provenance.intoto.jsonl") \
+            --provenance-path <(curl -fsSL "https://github.com/$REPO_NAME/releases/download/${TAG}/release-provenance.intoto.jsonl") \
             <(gh api "repos/$REPO_NAME/git/refs/tags/${TAG}" --jq '.object.sha')
 
           echo "✅ SLSA provenance verification successful"

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -324,15 +324,14 @@ jobs:
             ### 1) Using slsa-verifier
 
             ```
-            REPO="${{ github.repository }}"
             TAG="${{ needs.version.outputs.tag_name }}"
             # Fetch tag object SHA from GitHub API (same as `git rev-parse <tag>`)
-            TAG_SHA=$(curl -fsSL "https://api.github.com/repos/${{ github.repository }}/git/refs/tags/${{ needs.version.outputs.tag_name }}" | jq -r '.object.sha')
+            TAG_SHA=$(curl -fsSL "https://api.github.com/repos/${{ github.repository }}/git/refs/tags/${TAG}" | jq -r '.object.sha')
 
             # Verify SLSA provenance for the tag SHA virtual artifact
             slsa-verifier verify-artifact \
               --source-uri "github.com/${{ github.repository }}" \
-              --provenance-path <(curl -fsSL "https://github.com/${{ github.repository }}/releases/download/${{ needs.version.outputs.tag_name }}/release-provenance.intoto.jsonl") \
+              --provenance-path <(curl -fsSL "https://github.com/${{ github.repository }}/releases/download/${TAG}/release-provenance.intoto.jsonl") \
               <(echo "$TAG_SHA")
             ```
 

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -336,56 +336,56 @@ jobs:
           {
             echo "$RELEASE_NOTES"
             echo
-            cat <<EOF
-<details>
-<summary>📋 Release Verification Instructions</summary>
+            cat <<'EOF'
+            <details>
+            <summary>📋 Release Verification Instructions</summary>
 
-Verify this release and its tag provenance using the following examples.
+            Verify this release and its tag provenance using the following examples.
 
----
+            ---
 
-1) Using slsa-verifier (same approach as our verify-release job)
+            1) Using slsa-verifier (same approach as our verify-release job)
 
-```
-# Set variables
-REPO="${REPO}"
-TAG="${TAG_NAME}"
+            ```
+            # Set variables
+            REPO="${REPO}"
+            TAG="${TAG_NAME}"
 
-# Verify SLSA provenance for the tag SHA virtual artifact
-slsa-verifier verify-artifact \
-  --source-uri "github.com/${REPO}" \
-  --provenance-path <(curl -fsSL "https://github.com/${REPO}/releases/download/${TAG}/release-provenance.intoto.jsonl") \
-  <(gh api "repos/${REPO}/git/refs/tags/${TAG}" --jq '.object.sha')
-```
+            # Verify SLSA provenance for the tag SHA virtual artifact
+            slsa-verifier verify-artifact \
+              --source-uri "github.com/${REPO}" \
+              --provenance-path <(curl -fsSL "https://github.com/${REPO}/releases/download/${TAG}/release-provenance.intoto.jsonl") \
+              <(gh api "repos/${REPO}/git/refs/tags/${TAG}" --jq '.object.sha')
+            ```
 
-Expected output includes a success message indicating the provenance matches the source and subject.
+            Expected output includes a success message indicating the provenance matches the source and subject.
 
----
+            ---
 
-2) Using actionutils/trusted-tag-verifier (GitHub Actions example)
+            2) Using actionutils/trusted-tag-verifier (GitHub Actions example)
 
-Add a lightweight workflow step to verify the signed tag for this release:
+            Add a lightweight workflow step to verify the signed tag for this release:
 
-```
-name: Verify Release Tag
-on: [workflow_dispatch]
-jobs:
-  verify:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Verify tag signature and identity
-        uses: actionutils/trusted-tag-verifier@v0
-        with:
-          verify: '${REPO}@${TAG_NAME}'
-          fail-on-verification-error: 'true'
-          certificate-oidc-issuer: 'https://token.actions.githubusercontent.com'
-          certificate-identity-regexp: '^https://github.com/actionutils/trusted-tag-releaser'
-```
+            ```
+            name: Verify Release Tag
+            on: [workflow_dispatch]
+            jobs:
+              verify:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: Verify tag signature and identity
+                    uses: actionutils/trusted-tag-verifier@v0
+                    with:
+                      verify: '${REPO}@${TAG_NAME}'
+                      fail-on-verification-error: 'true'
+                      certificate-oidc-issuer: 'https://token.actions.githubusercontent.com'
+                      certificate-identity-regexp: '^https://github.com/actionutils/trusted-tag-releaser'
+            ```
 
-Adjust the identity regexp to your policy if you fork this workflow.
+            Adjust the identity regexp to your policy if you fork this workflow.
 
-</details>
-EOF
+            </details>
+          EOF
           } > "$NOTES_FILE"
 
           # Edit existing draft release (created by SLSA generator) with generated notes + verification section

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -319,25 +319,7 @@ jobs:
 
             Verify this release and its tag provenance using the following examples.
 
-            ---
-
-            ### 1) Using slsa-verifier
-
-            ```
-            TAG="${{ needs.version.outputs.tag_name }}"
-            # Fetch tag object SHA from GitHub API (same as `git rev-parse <tag>`)
-            TAG_SHA=$(curl -fsSL "https://api.github.com/repos/${{ github.repository }}/git/refs/tags/${TAG}" | jq -r '.object.sha')
-
-            # Verify SLSA provenance for the tag SHA virtual artifact
-            slsa-verifier verify-artifact \
-              --source-uri "github.com/${{ github.repository }}" \
-              --provenance-path <(curl -fsSL "https://github.com/${{ github.repository }}/releases/download/${TAG}/release-provenance.intoto.jsonl") \
-              <(echo "$TAG_SHA")
-            ```
-
-            ---
-
-            ### 2) Using [actionutils/trusted-tag-verifier](https://github.com/actionutils/trusted-tag-verifier) (GitHub Actions example)
+            ### 1) Using [actionutils/trusted-tag-verifier](https://github.com/actionutils/trusted-tag-verifier) (GitHub Actions example)
 
             ```
             jobs:
@@ -354,7 +336,7 @@ jobs:
 
             Note that it uses [gitsign](https://github.com/sigstore/gitsign) internally.
 
-            ### 3) Using [gitsign](https://github.com/sigstore/gitsign)
+            ### 2) Using [gitsign](https://github.com/sigstore/gitsign)
 
             Clone ${{ github.repository }} and run the following command.
 
@@ -364,6 +346,23 @@ jobs:
               --certificate-identity-regexp='^https://github.com/actionutils/trusted-tag-releaser' \
               ${{ needs.version.outputs.tag_name }}
             ```
+
+            ### 3) Using slsa-verifier
+
+            ```
+            TAG="${{ needs.version.outputs.tag_name }}"
+            # Fetch tag object SHA from GitHub API (same as `git rev-parse <tag>`)
+            TAG_SHA=$(curl -fsSL "https://api.github.com/repos/${{ github.repository }}/git/refs/tags/${TAG}" | jq -r '.object.sha')
+
+            # Verify SLSA provenance for the tag SHA virtual artifact
+            slsa-verifier verify-artifact \
+              --source-uri "github.com/${{ github.repository }}" \
+              --provenance-path <(curl -fsSL "https://github.com/${{ github.repository }}/releases/download/${TAG}/release-provenance.intoto.jsonl") \
+              <(echo "$TAG_SHA")
+            ```
+
+            Note: Unlike (1) and (2), it does not verify git tag signature but verifies the uploaded provenance.
+            Prefer (1) and (2) in general because there is a time lag between tag creation and release creation.
 
             </details>
         run: |

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -347,7 +347,7 @@ jobs:
               ${{ needs.version.outputs.tag_name }}
             ```
 
-            ### 3) Using slsa-verifier
+            ### 3) Using [slsa-verifier](https://github.com/slsa-framework/slsa-verifier)
 
             ```
             TAG="${{ needs.version.outputs.tag_name }}"

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -247,6 +247,7 @@ jobs:
       tag_name: ${{ steps.save-info.outputs.tag_name }}
       major_tag: ${{ steps.save-info.outputs.major_tag }}
       minor_tag: ${{ steps.save-info.outputs.minor_tag }}
+      base64_subjects: ${{ steps.compute-subjects.outputs.base64_subjects }}
     steps:
       # Save commit info for attestation
       - name: Harden the runner (Audit all outbound calls)
@@ -270,64 +271,49 @@ jobs:
             echo "minor_tag=$MINOR_TAG"
           } >> "$GITHUB_OUTPUT"
           echo "Using commit: $COMMIT_SHA with tag: $TAG_NAME for provenance"
-
-      # Generate release-identity.intoto.jsonl file for release verification
-      # Note: We intentionally do not include source code archives (zip/tar.gz) in the release attestation
-      # because GitHub does not guarantee their stability over time:
-      # - https://docs.github.com/en/repositories/working-with-files/using-files/downloading-source-code-archives#stability-of-source-code-archives
-      # - https://github.blog/open-source/git/update-on-the-future-stability-of-source-code-archives-and-hashes/
-      # Instead, we include the commit SHA in release-identity.intoto.jsonl and verify that it matches the SHA that the tag points to.
-      - name: Generate release identity file
-        id: generate-metadata
+      # Compute tag SHA (git rev-parse <tag>) and prepare SLSA generator subjects
+      - name: Compute tag SHA and subjects
+        id: compute-subjects
+        env:
+          GITHUB_TOKEN: ${{ secrets.github-token }}
         run: |
-          REPO_NAME="${GITHUB_REPOSITORY#*/}"
-          CREATED_AT=$(date +%s)  # Unix timestamp (seconds since epoch)
+          TAG_NAME='${{ steps.save-info.outputs.tag_name }}'
 
-          # Create release-identity.intoto.jsonl file using in-toto Statement format
-          cat > release-identity.intoto.jsonl << EOF
-          {
-            "_type": "https://in-toto.io/Statement/v0.1",
-            "predicateType": "https://github.com/actionutils/trusted-tag-releaser/tree/main/in-toto/release-identity/v1",
-            "subject": [
-              {
-                "name": "$REPO_NAME",
-                "digest": {
-                  "git": "${{ github.sha }}"
-                }
-              }
-            ],
-            "predicate": {
-              "version": "${{ needs.version.outputs.tag_name }}",
-              "created_at": $CREATED_AT,
-              "git": {
-                "tag": "${{ needs.version.outputs.tag_name }}",
-                "repository": "https://github.com/$GITHUB_REPOSITORY"
-              }
-            }
-          }
-          EOF
+          # Get the object SHA that the tag ref points to (matches `git rev-parse <tag>` semantics)
+          TAG_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/refs/tags/$TAG_NAME" --jq '.object.sha')
 
-          echo "Generated release-identity.intoto.jsonl"
+          # Create a deterministic virtual artifact content (not uploaded to release): the tag SHA without newline
+          printf "%s" "$TAG_SHA" > release-tag.sha
+
+          # Encode the exact sha256sum output ("<sha256>  <name>") as base64 for the SLSA generator
+          BASE64_SUBJECTS=$(sha256sum release-tag.sha | base64 -w0)
+
+          echo "base64_subjects=$BASE64_SUBJECTS" >> "$GITHUB_OUTPUT"
+          echo "Computed tag SHA (rev-parse): $TAG_SHA"
 
 
+  # Generate and upload SLSA provenance for the tag SHA artifact BEFORE creating the release content
+  slsa-provenance:
+    needs: [prepare-slsa]
+    if: needs.prepare-slsa.outputs.tag_name != ''
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+      attestations: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: ${{ needs.prepare-slsa.outputs.base64_subjects }}
+      upload-assets: true
+      upload-tag-name: ${{ needs.prepare-slsa.outputs.tag_name }}
+      draft-release: true
 
-      # Upload release-identity.intoto.jsonl as an artifact to share between jobs
-      - name: Upload release identity artifact
-        id: upload-identity
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: release-identity-intoto
-          path: release-identity.intoto.jsonl
-          retention-days: 1
-
-      - uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
-        with:
-          subject-path: release-identity.intoto.jsonl
+  
 
 
   # Create GitHub Release job
   release:
-    needs: [version, prepare-slsa]
+    needs: [version, prepare-slsa, slsa-provenance]
     if: needs.version.outputs.tag_name != ''
     runs-on: ubuntu-latest
     permissions:
@@ -345,15 +331,8 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.version.outputs.tag_name }}
 
-      # Download the artifacts from previous jobs
-
-      - name: Download release-identity.intoto.jsonl
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
-        with:
-          name: release-identity-intoto
-
-      # Create GitHub Release
-      - name: Create GitHub Release
+      # Create or update GitHub Release (draft may be pre-created by SLSA generator)
+      - name: Update GitHub Release
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.github-token }}
@@ -375,19 +354,18 @@ jobs:
             -f previous_tag_name="$CURRENT_VERSION" \
             --jq '.body')
 
-          # Create release with generated notes
-          RELEASE_URL=$(gh release create "$TAG_NAME" \
+          # Edit existing draft release (created by SLSA generator) with generated notes
+          RELEASE_URL=$(gh release edit "$TAG_NAME" \
             --title "Release $TAG_NAME" \
-            --draft=${{ inputs.draft }} \
             --notes "$RELEASE_NOTES" \
-            release-identity.intoto.jsonl)
+            --draft=${{ inputs.draft }})
 
           echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
           echo "Release URL: $RELEASE_URL"
 
   # Verify the release using gh attestation verify
   verify-release:
-    needs: [release, prepare-slsa]
+    needs: [release, slsa-provenance, version]
     if: needs.prepare-slsa.outputs.tag_name != ''
     runs-on: ubuntu-latest
     permissions:
@@ -407,77 +385,33 @@ jobs:
           echo "dir=$TEMP_DIR" >> "$GITHUB_OUTPUT"
           echo "Created temporary directory: $TEMP_DIR"
 
-      - name: Download files for verification
+      - name: Install slsa-verifier
+        uses: slsa-framework/slsa-verifier/actions/installer@v2.7.1
+
+      - name: Verify SLSA provenance with slsa-verifier
         env:
           GITHUB_TOKEN: ${{ secrets.github-token }}
         run: |
-          TAG_NAME="${{ needs.prepare-slsa.outputs.tag_name }}"
-          TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
-
-          # Download release-identity.intoto.jsonl
-          gh release download "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --pattern "release-identity.intoto.jsonl" --dir "$TEMP_DIR"
-
-          echo "Downloaded files to: $TEMP_DIR"
-          ls -la "$TEMP_DIR"
-
-      # Verify commit SHA
-      # Since we don't include source code archives in the release attestation due to their instability,
-      # we instead verify that the commit SHA in release-identity.intoto.jsonl matches the SHA that the tag points to.
-      # This provides a more reliable verification mechanism that isn't affected by GitHub's archive generation process.
-      - name: Verify commit SHA
-        env:
-          GITHUB_TOKEN: ${{ secrets.github-token }}
-        run: |
-          TAG_NAME="${{ needs.prepare-slsa.outputs.tag_name }}"
+          set -euo pipefail
           REPO_NAME="${GITHUB_REPOSITORY}"
+          TAG_NAME="${{ needs.version.outputs.tag_name }}"
           TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
 
-          # Use the identity file
-          IDENTITY_FILE="$TEMP_DIR/release-identity.intoto.jsonl"
-
-          if [ ! -f "$IDENTITY_FILE" ]; then
-            echo "Error: No release-identity.intoto.jsonl file found"
-            exit 1
-          fi
-
-          # Verify that the commit SHA in release-identity.intoto.jsonl matches the SHA that the tag points to
-          echo "Verifying commit SHA in release-identity.intoto.jsonl..."
-
-          # Get the commit SHA from release-identity.intoto.jsonl
-          IDENTITY_COMMIT_SHA=$(jq -r '.subject[0].digest.git' "$IDENTITY_FILE")
-
-          # Get the commit SHA that the tag points to using GitHub API
-          # First, get the tag SHA
+          # Get git rev-parse <tag> equivalent and avoid trailing newline
           TAG_SHA=$(gh api "repos/$REPO_NAME/git/refs/tags/$TAG_NAME" --jq '.object.sha')
-          echo "Tag SHA: $TAG_SHA"
 
-          # Then, get the commit SHA that the tag points to
-          TAG_COMMIT_SHA=$(gh api "repos/$REPO_NAME/git/tags/$TAG_SHA" --jq '.object.sha')
+          # Download provenance uploaded by SLSA generator
+          PROV_NAME='${{ needs.slsa-provenance.outputs.provenance-name }}'
+          gh release download "$TAG_NAME" --repo "$REPO_NAME" --pattern "$PROV_NAME" --dir "$TEMP_DIR"
 
-          echo "Commit SHA in release-identity.intoto.jsonl: $IDENTITY_COMMIT_SHA"
-          echo "Commit SHA that tag $TAG_NAME points to: $TAG_COMMIT_SHA"
+          echo "Verifying with slsa-verifier against provenance: $PROV_NAME"
+          slsa-verifier verify-artifact \
+            --source-uri "github.com/$REPO_NAME" \
+            --source-tag "$TAG_NAME" \
+            --provenance-path "$TEMP_DIR/$PROV_NAME" \
+            <(printf "%s" "$TAG_SHA")
 
-          # Verify that the commit SHAs match
-          if [ "$IDENTITY_COMMIT_SHA" != "$TAG_COMMIT_SHA" ]; then
-            echo "❌ Commit SHA verification failed! The commit SHA in release-identity.intoto.jsonl does not match the SHA that the tag points to."
-            exit 1
-          fi
-
-          echo "✅ Commit SHA verification successful!"
-
-
-      - name: Verify build provenance attestation
-        env:
-          GITHUB_TOKEN: ${{ secrets.github-token }}
-          GH_FORCE_TTY: 1
-        run: |
-          TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
-          IDENTITY_FILE="$TEMP_DIR/release-identity.intoto.jsonl"
-          echo "Verifying build provenance attestation for release-identity.intoto.jsonl"
-
-          gh attestation verify "$IDENTITY_FILE" --repo "$GITHUB_REPOSITORY" --signer-repo=actionutils/trusted-tag-releaser
-
-          echo "✅ Build provenance attestation verification successful!"
+          echo "✅ SLSA provenance verification successful"
 
       - name: Verify Tag
         id: verify-tag

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -286,6 +286,7 @@ jobs:
       upload-assets: true
       upload-tag-name: ${{ needs.version.outputs.tag_name }}
       draft-release: true
+      provenance-name: release-provenance.intoto.jsonl
 
   # Create GitHub Release job
   release:
@@ -366,7 +367,7 @@ jobs:
           TAG="${{ needs.version.outputs.tag_name }}"
           slsa-verifier verify-artifact \
             --source-uri "github.com/$REPO_NAME" \
-            --provenance-path <(curl -sfSL "https://github.com/$REPO_NAME/releases/download/${TAG}/${TAG}.sha.intoto.jsonl") \
+            --provenance-path <(curl -sfSL "https://github.com/$REPO_NAME/releases/download/release-provenance.intoto.jsonl") \
             <(gh api "repos/$REPO_NAME/git/refs/tags/${TAG}" --jq '.object.sha')
 
           echo "✅ SLSA provenance verification successful"

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -279,17 +279,15 @@ jobs:
         run: |
           TAG_NAME='${{ steps.save-info.outputs.tag_name }}'
 
-          # Get the object SHA that the tag ref points to (matches `git rev-parse <tag>` semantics)
-          TAG_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/refs/tags/$TAG_NAME" --jq '.object.sha')
-
-          # Create a deterministic virtual artifact content (not uploaded to release): the tag SHA without newline
-          printf "%s" "$TAG_SHA" > release-tag.sha
+          # Create a deterministic virtual artifact content directly from GitHub API (includes trailing newline)
+          # Equivalent to: git rev-parse <tag>
+          gh api "repos/$GITHUB_REPOSITORY/git/refs/tags/$TAG_NAME" --jq '.object.sha' > release-tag.sha
 
           # Encode the exact sha256sum output ("<sha256>  <name>") as base64 for the SLSA generator
           BASE64_SUBJECTS=$(sha256sum release-tag.sha | base64 -w0)
 
           echo "base64_subjects=$BASE64_SUBJECTS" >> "$GITHUB_OUTPUT"
-          echo "Computed tag SHA (rev-parse): $TAG_SHA"
+          echo "Computed tag SHA (rev-parse): $(cat release-tag.sha)"
 
 
   # Generate and upload SLSA provenance for the tag SHA artifact BEFORE creating the release content
@@ -397,8 +395,8 @@ jobs:
           TAG_NAME="${{ needs.version.outputs.tag_name }}"
           TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
 
-          # Get git rev-parse <tag> equivalent and avoid trailing newline
-          TAG_SHA=$(gh api "repos/$REPO_NAME/git/refs/tags/$TAG_NAME" --jq '.object.sha')
+          # Get git rev-parse <tag> equivalent via GitHub API and write to file for verification
+          gh api "repos/$REPO_NAME/git/refs/tags/$TAG_NAME" --jq '.object.sha' > "$TEMP_DIR/release-tag.sha"
 
           # Download provenance uploaded by SLSA generator
           PROV_NAME='${{ needs.slsa-provenance.outputs.provenance-name }}'
@@ -409,7 +407,7 @@ jobs:
             --source-uri "github.com/$REPO_NAME" \
             --source-tag "$TAG_NAME" \
             --provenance-path "$TEMP_DIR/$PROV_NAME" \
-            <(printf "%s" "$TAG_SHA")
+            "$TEMP_DIR/release-tag.sha"
 
           echo "✅ SLSA provenance verification successful"
 

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -340,8 +340,6 @@ jobs:
 
             ### 2) Using [actionutils/trusted-tag-verifier](https://github.com/actionutils/trusted-tag-verifier) (GitHub Actions example)
 
-            Add a lightweight workflow step to verify the signed tag for this release:
-
             ```
             jobs:
               verify:
@@ -353,6 +351,17 @@ jobs:
                       fail-on-verification-error: 'true'
                       certificate-oidc-issuer: 'https://token.actions.githubusercontent.com'
                       certificate-identity-regexp: '^https://github.com/actionutils/trusted-tag-releaser'
+            ```
+
+            ### 3) Using [gitsign](https://github.com/sigstore/gitsign)
+
+            Clone ${{ github.repository }} and run the following command.
+
+            ```
+            gitsign verify-tag \
+              --certificate-oidc-issuer='https://token.actions.githubusercontent.com'  \
+              --certificate-identity-regexp='^https://github.com/actionutils/trusted-tag-releaser' \
+              ${{ needs.version.outputs.tag_name }}
             ```
 
             </details>

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -74,6 +74,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
+          # shellcheck disable=SC2016,SC1003
           echo "# Release Check Summary" >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "${{ steps.bumpr-dry-run.outputs.skip }}" == "true" ]]; then
@@ -166,6 +167,7 @@ jobs:
 
       - name: Approve release
         run: |
+          # shellcheck disable=SC2016,SC1003
           echo "Release approved in the '${{ inputs.environment }}' environment"
           echo "This job exists to satisfy environment deployment requirements."
 
@@ -313,30 +315,7 @@ jobs:
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.github-token }}
-        run: |
-          TAG_NAME="${{ needs.version.outputs.tag_name }}"
-          REPO="${GITHUB_REPOSITORY}"
-
-          # Generate release notes using GitHub API
-          echo "Generating release notes using GitHub API..."
-          # Get the current version from bumpr output (will be empty string if not set)
-          CURRENT_VERSION="${{ needs.version.outputs.current_version }}"
-
-          # Call the API with the parameters
-          RELEASE_NOTES=$(gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/${REPO}/releases/generate-notes" \
-            -f tag_name="$TAG_NAME" \
-            -f previous_tag_name="$CURRENT_VERSION" \
-            --jq '.body')
-
-          # Append verification instructions to the generated release notes
-          NOTES_FILE="$(mktemp)"
-          {
-            echo "$RELEASE_NOTES"
-            echo
-            cat <<'EOF'
+          VERIFICATION_INSTRUCTIONS: |
             <details>
             <summary>📋 Release Verification Instructions</summary>
 
@@ -344,18 +323,21 @@ jobs:
 
             ---
 
-            1) Using slsa-verifier (same approach as our verify-release job)
+            1) Using slsa-verifier
 
             ```
-            # Set variables
-            REPO="${REPO}"
-            TAG="${TAG_NAME}"
+            # These values are pre-filled for this release
+            REPO="${{ github.repository }}"
+            TAG="${{ needs.version.outputs.tag_name }}"
+
+            # Fetch tag object SHA from GitHub API (same as `git rev-parse <tag>`)
+            TAG_SHA=$(curl -fsSL "https://api.github.com/repos/${{ github.repository }}/git/refs/tags/${{ needs.version.outputs.tag_name }}" | jq -r '.object.sha')
 
             # Verify SLSA provenance for the tag SHA virtual artifact
             slsa-verifier verify-artifact \
-              --source-uri "github.com/${REPO}" \
-              --provenance-path <(curl -fsSL "https://github.com/${REPO}/releases/download/${TAG}/release-provenance.intoto.jsonl") \
-              <(gh api "repos/${REPO}/git/refs/tags/${TAG}" --jq '.object.sha')
+              --source-uri "github.com/${{ github.repository }}" \
+              --provenance-path <(curl -fsSL "https://github.com/${{ github.repository }}/releases/download/${{ needs.version.outputs.tag_name }}/release-provenance.intoto.jsonl") \
+              <(echo "$TAG_SHA")
             ```
 
             Expected output includes a success message indicating the provenance matches the source and subject.
@@ -376,7 +358,7 @@ jobs:
                   - name: Verify tag signature and identity
                     uses: actionutils/trusted-tag-verifier@v0
                     with:
-                      verify: '${REPO}@${TAG_NAME}'
+                      verify: '${{ github.repository }}@${{ needs.version.outputs.tag_name }}'
                       fail-on-verification-error: 'true'
                       certificate-oidc-issuer: 'https://token.actions.githubusercontent.com'
                       certificate-identity-regexp: '^https://github.com/actionutils/trusted-tag-releaser'
@@ -385,8 +367,28 @@ jobs:
             Adjust the identity regexp to your policy if you fork this workflow.
 
             </details>
-          EOF
-          } > "$NOTES_FILE"
+        run: |
+          # shellcheck disable=SC2016
+          TAG_NAME="${{ needs.version.outputs.tag_name }}"
+          REPO="${GITHUB_REPOSITORY}"
+
+          # Generate release notes using GitHub API
+          echo "Generating release notes using GitHub API..."
+          # Get the current version from bumpr output (will be empty string if not set)
+          CURRENT_VERSION="${{ needs.version.outputs.current_version }}"
+
+          # Call the API with the parameters
+          RELEASE_NOTES=$(gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${REPO}/releases/generate-notes" \
+            -f tag_name="$TAG_NAME" \
+            -f previous_tag_name="$CURRENT_VERSION" \
+            --jq '.body')
+
+          # Append verification instructions to the generated release notes
+          NOTES_FILE="$(mktemp)"
+          printf "%s\n\n%s\n" "$RELEASE_NOTES" "$VERIFICATION_INSTRUCTIONS" > "$NOTES_FILE"
 
           # Edit existing draft release (created by SLSA generator) with generated notes + verification section
           RELEASE_URL=$(gh release edit "$TAG_NAME" \

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -337,7 +337,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.github-token }}
         run: |
-          TAG_NAME="${{ needs.prepare-slsa.outputs.tag_name }}"
+          TAG_NAME="${{ needs.version.outputs.tag_name }}"
           REPO="${GITHUB_REPOSITORY}"
 
           # Generate release notes using GitHub API
@@ -366,7 +366,7 @@ jobs:
   # Verify the release using gh attestation verify
   verify-release:
     needs: [release, slsa-provenance, version]
-    if: needs.prepare-slsa.outputs.tag_name != ''
+    if: needs.version.outputs.tag_name != ''
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required to read release artifacts
@@ -417,27 +417,27 @@ jobs:
         id: verify-tag
         uses: actionutils/trusted-tag-verifier@v0
         with:
-          verify: '${{ github.repository }}@${{ needs.prepare-slsa.outputs.tag_name }}'
+          verify: '${{ github.repository }}@${{ needs.version.outputs.tag_name }}'
           fail-on-verification-error: 'true'
           certificate-oidc-issuer: 'https://token.actions.githubusercontent.com'
           certificate-identity-regexp: '^https://github.com/actionutils/trusted-tag-releaser'
 
       - name: Verify Major Tag
         id: verify-major-tag
-        if: needs.prepare-slsa.outputs.major_tag != ''
+        if: needs.version.outputs.major_tag != ''
         uses: actionutils/trusted-tag-verifier@v0
         with:
-          verify: '${{ github.repository }}@${{ needs.prepare-slsa.outputs.major_tag }}'
+          verify: '${{ github.repository }}@${{ needs.version.outputs.major_tag }}'
           fail-on-verification-error: 'true'
           certificate-oidc-issuer: 'https://token.actions.githubusercontent.com'
           certificate-identity-regexp: '^https://github.com/actionutils/trusted-tag-releaser'
 
       - name: Verify Minor Tag
         id: verify-minor-tag
-        if: needs.prepare-slsa.outputs.minor_tag != ''
+        if: needs.version.outputs.minor_tag != ''
         uses: actionutils/trusted-tag-verifier@v0
         with:
-          verify: '${{ github.repository }}@${{ needs.prepare-slsa.outputs.minor_tag }}'
+          verify: '${{ github.repository }}@${{ needs.version.outputs.minor_tag }}'
           fail-on-verification-error: 'true'
           certificate-oidc-issuer: 'https://token.actions.githubusercontent.com'
           certificate-identity-regexp: '^https://github.com/actionutils/trusted-tag-releaser'

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -351,14 +351,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Create temporary directory
-        id: tempdir
-        run: |
-          # Create temporary directory
-          TEMP_DIR=$(mktemp -d)
-          echo "dir=$TEMP_DIR" >> "$GITHUB_OUTPUT"
-          echo "Created temporary directory: $TEMP_DIR"
-
       - name: Install slsa-verifier
         uses: slsa-framework/slsa-verifier/actions/installer@v2.7.1
 
@@ -367,24 +359,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.github-token }}
         run: |
           set -euo pipefail
+
           REPO_NAME="${GITHUB_REPOSITORY}"
-          TAG_NAME="${{ needs.version.outputs.tag_name }}"
-          TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
-
-          # Get git rev-parse <tag> equivalent via GitHub API and write to file for verification
-          TAG_SHA_FILE="$TEMP_DIR/${TAG_NAME}.sha"
-          gh api "repos/$REPO_NAME/git/refs/tags/$TAG_NAME" --jq '.object.sha' > "$TAG_SHA_FILE"
-
-          # Download provenance uploaded by SLSA generator
-          PROV_NAME='${{ needs.slsa-provenance.outputs.provenance-name }}'
-          gh release download "$TAG_NAME" --repo "$REPO_NAME" --pattern "$PROV_NAME" --dir "$TEMP_DIR"
-
-          echo "Verifying with slsa-verifier against provenance: $PROV_NAME"
+          TAG="${{ needs.version.outputs.tag_name }}"
           slsa-verifier verify-artifact \
             --source-uri "github.com/$REPO_NAME" \
-            --source-tag "$TAG_NAME" \
-            --provenance-path "$TEMP_DIR/$PROV_NAME" \
-            "$TAG_SHA_FILE"
+            --provenance-path <(curl -sfSL https://github.com/$REPO_NAME/releases/download/${TAG}/${TAG}.sha.intoto.jsonl) \
+            <(gh api "repos/$REPO_NAME/git/refs/tags/${TAG}" --jq '.object.sha')
 
           echo "✅ SLSA provenance verification successful"
 
@@ -416,13 +397,3 @@ jobs:
           fail-on-verification-error: 'true'
           certificate-oidc-issuer: 'https://token.actions.githubusercontent.com'
           certificate-identity-regexp: '^https://github.com/actionutils/trusted-tag-releaser'
-
-      - name: Cleanup
-        if: always()
-        run: |
-          # Clean up temporary directory
-          TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
-          if [ -d "$TEMP_DIR" ]; then
-            rm -rf "$TEMP_DIR"
-            echo "Temporary directory cleaned up: $TEMP_DIR"
-          fi

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -321,13 +321,11 @@ jobs:
 
             ---
 
-            1) Using slsa-verifier
+            ### 1) Using slsa-verifier
 
             ```
-            # These values are pre-filled for this release
             REPO="${{ github.repository }}"
             TAG="${{ needs.version.outputs.tag_name }}"
-
             # Fetch tag object SHA from GitHub API (same as `git rev-parse <tag>`)
             TAG_SHA=$(curl -fsSL "https://api.github.com/repos/${{ github.repository }}/git/refs/tags/${{ needs.version.outputs.tag_name }}" | jq -r '.object.sha')
 
@@ -338,31 +336,24 @@ jobs:
               <(echo "$TAG_SHA")
             ```
 
-            Expected output includes a success message indicating the provenance matches the source and subject.
-
             ---
 
-            2) Using actionutils/trusted-tag-verifier (GitHub Actions example)
+            ### 2) Using [actionutils/trusted-tag-verifier](https://github.com/actionutils/trusted-tag-verifier) (GitHub Actions example)
 
             Add a lightweight workflow step to verify the signed tag for this release:
 
             ```
-            name: Verify Release Tag
-            on: [workflow_dispatch]
             jobs:
               verify:
                 runs-on: ubuntu-latest
                 steps:
-                  - name: Verify tag signature and identity
-                    uses: actionutils/trusted-tag-verifier@v0
+                  - uses: actionutils/trusted-tag-verifier@v0
                     with:
                       verify: '${{ github.repository }}@${{ needs.version.outputs.tag_name }}'
                       fail-on-verification-error: 'true'
                       certificate-oidc-issuer: 'https://token.actions.githubusercontent.com'
                       certificate-identity-regexp: '^https://github.com/actionutils/trusted-tag-releaser'
             ```
-
-            Adjust the identity regexp to your policy if you fork this workflow.
 
             </details>
         run: |

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -182,8 +182,6 @@ jobs:
       tag_name: ${{ steps.tag.outputs.value }}
       version: ${{ steps.extract-version.outputs.version }}
       current_version: ${{ steps.bumpr.outputs.current_version }}
-      major_tag: ${{ steps.update-semver.outputs.major }}
-      minor_tag: ${{ steps.update-semver.outputs.minor }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -243,10 +241,6 @@ jobs:
       contents: read    # Required for attestation
       attestations: write # Required for creating attestations
     outputs:
-      commit_sha: ${{ steps.save-info.outputs.commit_sha }}
-      tag_name: ${{ steps.save-info.outputs.tag_name }}
-      major_tag: ${{ steps.save-info.outputs.major_tag }}
-      minor_tag: ${{ steps.save-info.outputs.minor_tag }}
       base64_subjects: ${{ steps.compute-subjects.outputs.base64_subjects }}
     steps:
       # Save commit info for attestation
@@ -255,29 +249,13 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Save commit info
-        id: save-info
-        run: |
-          COMMIT_SHA="${{ github.sha }}"
-          TAG="${{ needs.version.outputs.tag_name }}"
-          TAG_NAME="${TAG#refs/tags/}"
-          MAJOR_TAG="${{ needs.version.outputs.major_tag }}"
-          MINOR_TAG="${{ needs.version.outputs.minor_tag }}"
-
-          {
-            echo "commit_sha=$COMMIT_SHA"
-            echo "tag_name=$TAG_NAME"
-            echo "major_tag=$MAJOR_TAG"
-            echo "minor_tag=$MINOR_TAG"
-          } >> "$GITHUB_OUTPUT"
-          echo "Using commit: $COMMIT_SHA with tag: $TAG_NAME for provenance"
       # Compute tag SHA (git rev-parse <tag>) and prepare SLSA generator subjects
       - name: Compute tag SHA and subjects
         id: compute-subjects
         env:
           GITHUB_TOKEN: ${{ secrets.github-token }}
         run: |
-          TAG_NAME='${{ steps.save-info.outputs.tag_name }}'
+          TAG_NAME='${{ needs.version.outputs.tag_name }}'
 
           # Create a deterministic virtual artifact content directly from GitHub API (includes trailing newline)
           # Equivalent to: git rev-parse <tag>
@@ -293,8 +271,8 @@ jobs:
 
   # Generate and upload SLSA provenance for the tag SHA artifact BEFORE creating the release content
   slsa-provenance:
-    needs: [prepare-slsa]
-    if: needs.prepare-slsa.outputs.tag_name != ''
+    needs: [version, prepare-slsa]
+    if: needs.version.outputs.tag_name != ''
     permissions:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
@@ -304,15 +282,12 @@ jobs:
     with:
       base64-subjects: ${{ needs.prepare-slsa.outputs.base64_subjects }}
       upload-assets: true
-      upload-tag-name: ${{ needs.prepare-slsa.outputs.tag_name }}
+      upload-tag-name: ${{ needs.version.outputs.tag_name }}
       draft-release: true
-
-  
-
 
   # Create GitHub Release job
   release:
-    needs: [version, prepare-slsa, slsa-provenance]
+    needs: [version, slsa-provenance]
     if: needs.version.outputs.tag_name != ''
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -74,7 +74,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          # shellcheck disable=SC2016,SC1003
           echo "# Release Check Summary" >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "${{ steps.bumpr-dry-run.outputs.skip }}" == "true" ]]; then
@@ -167,8 +166,7 @@ jobs:
 
       - name: Approve release
         run: |
-          # shellcheck disable=SC2016,SC1003
-          echo "Release approved in the '${{ inputs.environment }}' environment"
+          echo "Release approved in the ${{ inputs.environment }} environment"
           echo "This job exists to satisfy environment deployment requirements."
 
   # Version management and tag creation job
@@ -368,7 +366,6 @@ jobs:
 
             </details>
         run: |
-          # shellcheck disable=SC2016
           TAG_NAME="${{ needs.version.outputs.tag_name }}"
           REPO="${GITHUB_REPOSITORY}"
 

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -353,6 +353,8 @@ jobs:
                       certificate-identity-regexp: '^https://github.com/actionutils/trusted-tag-releaser'
             ```
 
+            Note that it uses [gitsign](https://github.com/sigstore/gitsign) internally.
+
             ### 3) Using [gitsign](https://github.com/sigstore/gitsign)
 
             Clone ${{ github.repository }} and run the following command.

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -182,6 +182,8 @@ jobs:
       tag_name: ${{ steps.tag.outputs.value }}
       version: ${{ steps.extract-version.outputs.version }}
       current_version: ${{ steps.bumpr.outputs.current_version }}
+      major_tag: ${{ steps.update-semver.outputs.major }}
+      minor_tag: ${{ steps.update-semver.outputs.minor }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -364,7 +366,7 @@ jobs:
           TAG="${{ needs.version.outputs.tag_name }}"
           slsa-verifier verify-artifact \
             --source-uri "github.com/$REPO_NAME" \
-            --provenance-path <(curl -sfSL https://github.com/$REPO_NAME/releases/download/${TAG}/${TAG}.sha.intoto.jsonl) \
+            --provenance-path <(curl -sfSL "https://github.com/$REPO_NAME/releases/download/${TAG}/${TAG}.sha.intoto.jsonl") \
             <(gh api "repos/$REPO_NAME/git/refs/tags/${TAG}" --jq '.object.sha')
 
           echo "✅ SLSA provenance verification successful"


### PR DESCRIPTION
This PR refactors the release workflow to:
- Use tag SHA (git rev-parse <tag>) as the virtual artifact
- Generate SLSA provenance with slsa-framework generic generator v2.1.0
- Do not upload the tag SHA file to the release; upload provenance only
- Verify using slsa-verifier; depend on release job
- Reorder jobs: provenance -> release -> verify