### PR TITLE
feat: add workflow URL output and exit-status flag in E2E test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -229,10 +229,11 @@ jobs:
 
           if [ -n "$LATEST_RUN_ID" ] && [ "$LATEST_RUN_ID" != "null" ]; then
             echo "Found release workflow run: $LATEST_RUN_ID"
+            echo "Workflow URL: https://github.com/actionutils/test-trusted-tag-releaser/actions/runs/$LATEST_RUN_ID"
             echo "Watching workflow progress..."
 
             # Watch the workflow run until completion
-            gh run watch "$LATEST_RUN_ID" --repo actionutils/test-trusted-tag-releaser
+            gh run watch "$LATEST_RUN_ID" --compact --exit-status --repo actionutils/test-trusted-tag-releaser
 
             echo "✅ Release workflow completed!"
           else


### PR DESCRIPTION
## Summary
- Display the GitHub Actions workflow URL before watching the release workflow run for better visibility during E2E test execution
- Add `--exit-status` flag to `gh run watch` command to ensure the E2E test fails if the watched workflow fails

## Test plan
- [ ] Run the E2E workflow and verify the URL is displayed in the logs
- [ ] Confirm the workflow watching still works as expected
- [ ] Verify that if the release workflow fails, the E2E test also fails with proper exit code

🤖 Generated with [Claude Code](https://claude.ai/code)