### PR TITLE
fix: add workaround for GitHub workflow permission error during tag push

### DIFF
--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -218,6 +218,31 @@ jobs:
       - id: bumpr
         uses: haya14busa/action-bumpr@faf6f474bcb6174125cfc569f0b2e24cbf03d496 # v1.11.4
 
+      # Create temporary branch to prevent GitHub workflow permission error
+      # This is a workaround for the issue where pushing tags fails if no branch head
+      # contains the same workflow files as the tagged commit.
+      # See: https://github.com/orgs/community/discussions/151442
+      - name: Create temporary branch for tag push workaround
+        if: steps.bumpr.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.github-token }}
+        run: |
+          TAG_NAME="${{ steps.bumpr.outputs.next_version }}"
+          TEMP_BRANCH="keep-ref-${TAG_NAME}"
+
+          echo "Creating temporary branch '${TEMP_BRANCH}' as workaround for GitHub workflow permission issue"
+          echo "This prevents 'refusing to allow a GitHub App to create or update workflow' errors"
+          echo "when the main branch is updated with different workflow files during release."
+
+          # Create and push the temporary branch pointing to the current commit
+          git checkout -b "${TEMP_BRANCH}"
+          git push origin "${TEMP_BRANCH}"
+
+          # Switch back to the original state
+          git checkout -
+
+          echo "temp_branch=${TEMP_BRANCH}" >> "$GITHUB_OUTPUT"
+
       # Note: Major and minor tags will be updated after release creation
 
       # Get tag name from bumpr output only
@@ -445,6 +470,27 @@ jobs:
         id: update-semver
         with:
           tag: ${{ needs.version.outputs.tag_name }}
+
+      # Clean up temporary branch created during tag push
+      # This branch was created as a workaround for GitHub's workflow permission issue
+      # See: https://github.com/orgs/community/discussions/151442
+      - name: Delete temporary branch after successful tag creation
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ secrets.github-token }}
+        run: |
+          TAG_NAME="${{ needs.version.outputs.tag_name }}"
+          TEMP_BRANCH="keep-ref-${TAG_NAME}"
+
+          echo "Cleaning up temporary branch '${TEMP_BRANCH}' after successful release"
+
+          # Delete the temporary branch (ignore errors if it doesn't exist)
+          if gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/${TEMP_BRANCH}" --silent 2>/dev/null; then
+            gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${TEMP_BRANCH}" || true
+            echo "✓ Temporary branch deleted successfully"
+          else
+            echo "✓ Temporary branch already deleted or doesn't exist"
+          fi
 
   # Verify the release using gh attestation verify
   verify-release:


### PR DESCRIPTION
## Summary

This PR implements a workaround for a known GitHub issue where pushing tags fails with the error:
> refusing to allow a GitHub App to create or update workflow .github/workflows/foo.yaml without workflows permission

This error occurs when pushing a tag that points to a commit where the workflow files differ from the HEAD of any existing branch.

## Problem

As documented in [GitHub Community Discussion #151442](https://github.com/orgs/community/discussions/151442), GitHub incorrectly requires workflow write permissions when pushing tags, even though tags don't actually create or update workflows. This causes release workflows to fail if the main branch is updated with different workflow files while a release is in progress.

## Solution

The workaround creates a temporary branch (`keep-ref-<tag>`) at the release commit before pushing the tag, ensuring that a branch always exists with the exact workflow files from that commit. After successful tag creation, the temporary branch is deleted.

### Implementation Details

1. **Create temporary branch** (in `version` job):
   - After bumpr determines the next version
   - Creates branch named `keep-ref-<version>` at the current commit
   - Pushes this branch to origin

2. **Clean up temporary branch** (in `update-version-tags` job):
   - After all tags are successfully created and updated
   - Deletes the temporary branch using GitHub API
   - Runs with `if: always()` to ensure cleanup even on partial failures

## Why This Works

GitHub's permission check apparently verifies that at least one branch HEAD contains the same workflow files as the tagged commit. By maintaining a temporary branch during the tag creation process, we satisfy this check without needing workflow write permissions.

## Alternative Approaches Considered

- Using workflow write permissions: Not desirable for security reasons
- Retrying tag push: Doesn't work if main branch has diverged
- Creating tag before workflow changes: Not feasible in automated release flows

## Test Plan

- [x] Workflow syntax validated with `actionlint`
- [ ] Will be tested in the next release cycle
- [ ] Temporary branch creation and deletion verified to work with GitHub API

## Related Issues

- GitHub Community Discussion: https://github.com/orgs/community/discussions/151442
- This is a defensive workaround until GitHub fixes the underlying issue

🤖 Generated with [Claude Code](https://claude.ai/code)